### PR TITLE
Add guard to check which process.type the config module is called from

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,5 +1,9 @@
 if (process.versions && process.versions.electron) {
-  process.env.NODE_CONFIG_DIR = require('electron').app.getAppPath() + '/config';
+  if(process.type === "browser") {
+      process.env.NODE_CONFIG_DIR = require('electron').app.getAppPath() + '/config';
+  } else if (process.type == "renderer") {
+      process.env.NODE_CONFIG_DIR = require('electron').remote.app.getAppPath() + '/config';
+  }
 }
 
 module.exports = require('config');

--- a/index.js
+++ b/index.js
@@ -1,7 +1,7 @@
 if (process.versions && process.versions.electron) {
   if(process.type === "browser") {
       process.env.NODE_CONFIG_DIR = require('electron').app.getAppPath() + '/config';
-  } else if (process.type == "renderer") {
+  } else if (process.type === "renderer") {
       process.env.NODE_CONFIG_DIR = require('electron').remote.app.getAppPath() + '/config';
   }
 }

--- a/test/electronStub/index.js
+++ b/test/electronStub/index.js
@@ -1,5 +1,5 @@
 process.versions.electron = '1.0.0';
-
+process.type = "browser";
 module.exports = {
   app: {
     getAppPath: function () {

--- a/test/rendererStub/index.js
+++ b/test/rendererStub/index.js
@@ -1,0 +1,13 @@
+process.versions.electron = '1.0.0';
+process.type = "renderer";
+
+module.exports = {
+    remote: {
+        app: {
+            getAppPath: function () {
+                return `${__dirname}/../testFiles`
+            }
+        }
+    }
+
+};

--- a/test/test.js
+++ b/test/test.js
@@ -1,19 +1,35 @@
-const chai = require('chai');
-const should = chai.should();
+const chai       = require('chai');
+const should     = chai.should();
 const proxyquire = require('proxyquire');
-const electronStub = require('./electronStub');
 
-describe('electron-node-config', function () {  
-  it('should return a json object defined in ./testFiles/config/default.json', function () {
-    let config = proxyquire('../index', { 'electron': electronStub });
-    config.should.be.json;
-    config.should.have.property('tier', 'development');
-    config.should.have.property('development');
-    config.should.have.property('production');
-    config.development.should.be.json;
-    config.development.should.have.property('property1', 'devValue1');
-    config.development.should.have.property('property2', 'devValue2');
-    config.production.should.have.property('property1', 'prodValue1');
-    config.production.should.have.property('property2', 'prodValue2');
-  });
+
+describe('electron-node-config::browser', function () {
+    it('should return a json object defined in ./testFiles/config/default.json', function () {
+        const electronStub = require('./electronStub');
+        let config         = proxyquire('../index', {'electron': electronStub});
+        config.should.be.json;
+        config.should.have.property('tier', 'development');
+        config.should.have.property('development');
+        config.should.have.property('production');
+        config.development.should.be.json;
+        config.development.should.have.property('property1', 'devValue1');
+        config.development.should.have.property('property2', 'devValue2');
+        config.production.should.have.property('property1', 'prodValue1');
+        config.production.should.have.property('property2', 'prodValue2');
+    });
+});
+describe('electron-node-config::renderer', function () {
+    it('should return a json object defined in ./testFiles/config/default.json', function () {
+        const rendererStub = require('./rendererStub');
+        let config         = proxyquire('../index', {'electron': rendererStub});
+        config.should.be.json;
+        config.should.have.property('tier', 'development');
+        config.should.have.property('development');
+        config.should.have.property('production');
+        config.development.should.be.json;
+        config.development.should.have.property('property1', 'devValue1');
+        config.development.should.have.property('property2', 'devValue2');
+        config.production.should.have.property('property1', 'prodValue1');
+        config.production.should.have.property('property2', 'prodValue2');
+    });
 });


### PR DESCRIPTION
This prevents "Cannot read property 'getAppPath' of undefined" Errors in Renderer processes on Electron ^1.6

### Comments
Not sure if this is something you want to add, but I added it as I wasn't using globals to store the config object, therefore when I tried to load the package from the renderer process I got the `Cannot read property 'getAppPath' of undefined` as the `app` prop only exists on `require('electron');` on the Main process. In the renderers you have to use `remote`